### PR TITLE
[Fixed] bEquipeed Pointer Null Exception

### DIFF
--- a/Source/ToreThirdPersonCPP/Actions/CDoAction.cpp
+++ b/Source/ToreThirdPersonCPP/Actions/CDoAction.cpp
@@ -30,5 +30,5 @@ void ACDoAction::SetDatas(const TArray<FDoActionData>& InDatas)
 
 void ACDoAction::SetEquipped(const bool* InEquipped)
 {
-	InEquipped = bEquipped;
+	bEquipped = InEquipped;
 }

--- a/Source/ToreThirdPersonCPP/Actions/CDoAction_Warp.cpp
+++ b/Source/ToreThirdPersonCPP/Actions/CDoAction_Warp.cpp
@@ -26,7 +26,7 @@ void ACDoAction_Warp::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 
 	PreviewMeshComp->SetVisibility(false);
-	//CheckFalse(*bEquipped);
+	CheckFalse(*bEquipped);
 
 	FVector CurLoc;
 	FRotator CurRot;

--- a/Source/ToreThirdPersonCPP/Components/CActionComponent.h
+++ b/Source/ToreThirdPersonCPP/Components/CActionComponent.h
@@ -2,7 +2,6 @@
 
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Components/CActionComponent.h"
 #include "CActionComponent.generated.h"
 
 class UCActionData;


### PR DESCRIPTION
다시 보니 좌우가 바뀌어 있었어요...
```c++
void ACDoAction::SetEquipped(const bool* InEquipped)
{
	bEquipped = InEquipped;
}
```

헤더 파일이 순환 참조가 되는 부분도 수정했답니다.
(CActionComponent.h 파일에 #include "CActionComponent" 가 도 있었음-,.-;)